### PR TITLE
fix: make yc cli install atomic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,8 +35,12 @@ runs:
       if: steps.cache-yc-cli.outputs.cache-hit != 'true'
       shell: bash
       run: |
+        tmp="$(mktemp)"
+        
         echo "Downloading yc cli version ${{ steps.version.outputs.version }}"
-        sudo curl --fail "https://storage.yandexcloud.net/yandexcloud-yc/release/${{ steps.version.outputs.version }}/linux/amd64/yc" -o /usr/local/bin/yc
+        sudo curl --fail "https://storage.yandexcloud.net/yandexcloud-yc/release/${{ steps.version.outputs.version }}/linux/amd64/yc" -o "$tmp"
+        sudo install -m 755 "$tmp" /usr/local/bin/yc
+        rm -f "$tmp"
 
     - name: Set permissions for yc cli binary
       shell: bash


### PR DESCRIPTION
## Что сделано

- Изменена логика установки yc 
- Вместо прямой записи в /usr/local/bin/yc бинарник сначала скачивается во временный файл, а затем атомарно переносится на место через install.
- Тем самым устраняется ошибка Text file busy, возникавшая при попытке перезаписать выполняющийся бинарник yc 

## Мотивация

При одновременном выполнении нескольких job’ов на одном раннере один workflow мог использовать yc, пока другой пытался скачать и перезаписать тот же файл /usr/local/bin/yc. В такой ситуации система возвращала ошибку _/usr/local/bin/yc: Text file busy_